### PR TITLE
Cuda refactor/add eclipse ide ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,3 @@ docs/api/
 
 # Ignore DASK temporary files
 dask-worker-space/*
-
-#Eclipse synchronized project
-.ptp-sync-folder
-.ptp-sync/
-.pydevproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,15 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 file(STRINGS "qiskit_aer/VERSION.txt" VERSION_NUM)
 
+# Add CUDA to the project if needed.
+set(EXTRA_LANGUAGES "")
+if(AER_THRUST_BACKEND STREQUAL "CUDA")
+  list(APPEND EXTRA_LANGUAGES CUDA)
+endif()
+
 include(CheckLanguage)
-project(qasm_simulator VERSION ${VERSION_NUM} LANGUAGES CXX C)
+project(qasm_simulator VERSION ${VERSION_NUM} LANGUAGES CXX C ${EXTRA_LANGUAGES} )
+
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/cmake)
@@ -284,7 +291,7 @@ if(AER_THRUST_SUPPORTED)
 			set(CMAKE_CUDA_RUNTIME_LIBRARY None)
 
 
-			set(CUDA_NVCC_FLAGS "${AER_CUDA_ARCH_FLAGS_EXPAND} -DAER_THRUST_CUDA -I${AER_SIMULATOR_CPP_SRC_DIR} -isystem ${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers -use_fast_math --expt-extended-lambda")
+			set(CUDA_NVCC_FLAGS "${AER_CUDA_ARCH_FLAGS_EXPAND} -DAER_THRUST_GPU -DAER_THRUST_CUDA -I${AER_SIMULATOR_CPP_SRC_DIR} -isystem ${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers -use_fast_math --expt-extended-lambda")
 			set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -I${PYTHON_SITE_PATH}/cuquantum/include")
 			set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -I${PYTHON_SITE_PATH}/cutensor/include")
 			set(THRUST_DEPENDANT_LIBS "${THRUST_DEPENDANT_LIBS} -Wl,--disable-new-dtags")
@@ -311,7 +318,7 @@ if(AER_THRUST_SUPPORTED)
 			string(STRIP ${CUDA_NVCC_FLAGS} CUDA_NVCC_FLAGS)
 			string(STRIP ${THRUST_DEPENDANT_LIBS} THRUST_DEPENDANT_LIBS)
 		else()
-			set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${AER_CUDA_ARCH_FLAGS_EXPAND} -DAER_THRUST_CUDA -I${AER_SIMULATOR_CPP_SRC_DIR} -isystem ${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers -use_fast_math --expt-extended-lambda")
+			set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${AER_CUDA_ARCH_FLAGS_EXPAND} -DAER_THRUST_GPU -DAER_THRUST_CUDA -I${AER_SIMULATOR_CPP_SRC_DIR} -isystem ${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers -use_fast_math --expt-extended-lambda")
 
 			set(AER_COMPILER_DEFINITIONS ${AER_COMPILER_DEFINITIONS} THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA)
 			set(THRUST_DEPENDANT_LIBS "-L${CUDA_TOOLKIT_ROOT_DIR}/lib64")
@@ -455,7 +462,6 @@ else() # Standalone build
 			LINK_FLAGS ${AER_LINKER_FLAGS}
 			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
 			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
-		enable_language(CUDA)
 	endfunction()
 
 	function(build_cpu target src_file is_exec)
@@ -519,7 +525,9 @@ else() # Standalone build
 		if(BUILD_TESTS AND NOT AER_MPI)
 			add_executable(test_libaer "${PROJECT_SOURCE_DIR}/test/runtime/runtime_sample.c")
 			target_include_directories(test_libaer PUBLIC "${PROJECT_SOURCE_DIR}/contrib/runtime/")
-			set_target_properties(test_libaer PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE bin)
+      # AER_LINKER_FLAGS carry eventual OpenMP linking flags.
+			set_target_properties(test_libaer PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE bin
+                                              		 LINK_FLAGS ${AER_LINKER_FLAGS})
 			target_link_libraries(test_libaer PRIVATE ${AER_LIBRARIES})
 			target_link_libraries(test_libaer PRIVATE aer)
 			add_test(NAME aer_runtime_test COMMAND bin/test_libaer)

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -210,6 +210,7 @@ BASIS_GATES = {
             "swap",
             "delay",
             "pauli",
+            "ecr",
         ]
     ),
     "extended_stabilizer": sorted(

--- a/qiskit_aer/backends/qasm_simulator.py
+++ b/qiskit_aer/backends/qasm_simulator.py
@@ -785,6 +785,7 @@ class QasmSimulator(AerBackend):
                     "swap",
                     "delay",
                     "pauli",
+                    "ecr",
                 ]
             )
         if method == "extended_stabilizer":

--- a/releasenotes/notes/enhancement_ecr_for_stabilizer_simulator-00110a1b39d35054.yaml
+++ b/releasenotes/notes/enhancement_ecr_for_stabilizer_simulator-00110a1b39d35054.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Enable 2-qubit gate ECR for aer_stabilizer_simulator. Refer to
+    `#1883 <https://github.com/Qiskit/qiskit-aer/issues/1883` for more
+    details.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -285,7 +285,7 @@ void Controller::set_config(const Config &config) {
     sim_device_ = Device::ThrustCPU;
 #endif
   } else if (sim_device_name_ == "GPU") {
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
     throw std::runtime_error(
         "Simulation device \"GPU\" is not supported on this system");
 #else
@@ -421,7 +421,7 @@ size_t Controller::get_system_memory_mb() {
 
 size_t Controller::get_gpu_memory_mb() {
   size_t total_physical_memory = 0;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   int iDev, nDev, j;
   if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
     cudaGetLastError();

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -439,7 +439,7 @@ private:
 };
 
 bool AerState::is_gpu(bool raise_error) const {
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
   if (raise_error)
     throw std::runtime_error(
         "Simulation device \"GPU\" is not supported on this system");

--- a/src/misc/gpu_static_properties.hpp
+++ b/src/misc/gpu_static_properties.hpp
@@ -1,0 +1,24 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright AMD 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#ifndef __GPU_STATIC_PRIORITIES_H__
+#define __GPU_STATIC_PRIORITIES_H__
+
+#ifdef AER_THRUST_CUDA
+// In CUDA warpSize could not be a compile-time constant so we use 32 directly.
+#define _WS 32
+// Maximum number of threads in a block.
+#define _MAX_THD 1024
+#endif //AER_THRUST_CUDA
+
+#endif //__GPU_STATIC_PRIORITIES_H__

--- a/src/misc/gpu_static_properties.hpp
+++ b/src/misc/gpu_static_properties.hpp
@@ -19,6 +19,6 @@
 #define _WS 32
 // Maximum number of threads in a block.
 #define _MAX_THD 1024
-#endif //AER_THRUST_CUDA
+#endif // AER_THRUST_CUDA
 
 #endif //__GPU_STATIC_PRIORITIES_H__

--- a/src/misc/wrap_thrust.hpp
+++ b/src/misc/wrap_thrust.hpp
@@ -38,7 +38,7 @@ DISABLE_WARNING_PUSH
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 #include <thrust/device_vector.h>
 #endif
 #include <thrust/host_vector.h>

--- a/src/simulators/batch_shots_executor.hpp
+++ b/src/simulators/batch_shots_executor.hpp
@@ -268,7 +268,7 @@ void BatchShotsExecutor<state_t>::run_circuit_shots(
   }
 #endif
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (Base::sim_device_ == Device::GPU) {
     int nDev;
     if (cudaGetDeviceCount(&nDev) != cudaSuccess) {

--- a/src/simulators/circuit_executor.hpp
+++ b/src/simulators/circuit_executor.hpp
@@ -294,7 +294,7 @@ void Executor<state_t>::set_config(const Config &config) {
   }
 
   // set target GPUs
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   int nDev = 0;
   if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
     cudaGetLastError();
@@ -332,7 +332,7 @@ size_t Executor<state_t>::get_system_memory_mb() {
 template <class state_t>
 size_t Executor<state_t>::get_gpu_memory_mb() {
   size_t total_physical_memory = 0;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   for (int_t iDev = 0; iDev < target_gpus_.size(); iDev++) {
     size_t freeMem, totalMem;
     cudaSetDevice(target_gpus_[iDev]);

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -51,7 +51,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Return the string name of the class
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   static std::string name() { return "density_matrix_gpu"; }
 #else
   static std::string name() { return "density_matrix_thrust"; }

--- a/src/simulators/parallel_state_executor.hpp
+++ b/src/simulators/parallel_state_executor.hpp
@@ -796,7 +796,7 @@ void ParallelStateExecutor<state_t>::apply_ops_chunks(InputIterator first,
   }
 
   if (Base::sim_device_ == Device::GPU) {
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
     int nDev;
     if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
       cudaGetLastError();

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -39,9 +39,25 @@ const Operations::OpSet StateOpSet(
      OpType::save_state, OpType::set_stabilizer, OpType::jump, OpType::mark},
     // Gates
     {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg", "sx",
-     "sxdg", "delay", "pauli"});
+     "sxdg", "delay", "pauli", "ecr"});
 
-enum class Gates { id, x, y, z, h, s, sdg, sx, sxdg, cx, cy, cz, swap, pauli };
+enum class Gates {
+  id,
+  x,
+  y,
+  z,
+  h,
+  s,
+  sdg,
+  sx,
+  sxdg,
+  cx,
+  cy,
+  cz,
+  swap,
+  pauli,
+  ecr
+};
 
 //============================================================================
 // Stabilizer Table state class
@@ -181,12 +197,13 @@ const stringmap_t<Gates> State::gateset_({
     {"sx", Gates::sx},     // Sqrt X gate.
     {"sxdg", Gates::sxdg}, // Inverse Sqrt X gate.
     // Two-qubit gates
-    {"CX", Gates::cx},      // Controlled-X gate (CNOT)
-    {"cx", Gates::cx},      // Controlled-X gate (CNOT),
-    {"cy", Gates::cy},      // Controlled-Y gate
-    {"cz", Gates::cz},      // Controlled-Z gate
-    {"swap", Gates::swap},  // SWAP gate
-    {"pauli", Gates::pauli} // Pauli gate
+    {"CX", Gates::cx},       // Controlled-X gate (CNOT)
+    {"cx", Gates::cx},       // Controlled-X gate (CNOT),
+    {"cy", Gates::cy},       // Controlled-Y gate
+    {"cz", Gates::cz},       // Controlled-Z gate
+    {"swap", Gates::swap},   // SWAP gate
+    {"pauli", Gates::pauli}, // Pauli gate
+    {"ecr", Gates::ecr}      // ECR gate
 });
 
 //============================================================================
@@ -341,6 +358,16 @@ void State::apply_gate(const Operations::Op &op) {
     break;
   case Gates::pauli:
     apply_pauli(op.qubits, op.string_params[0]);
+    break;
+  case Gates::ecr:
+    BaseState::qreg_.append_h(op.qubits[1]);
+    BaseState::qreg_.append_s(op.qubits[0]);
+    BaseState::qreg_.append_z(op.qubits[1]); // sdg(1)
+    BaseState::qreg_.append_s(op.qubits[1]); // sdg(1)
+    BaseState::qreg_.append_h(op.qubits[1]);
+    BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+    BaseState::qreg_.append_x(op.qubits[0]);
+    BaseState::qreg_.append_x(op.qubits[1]);
     break;
   default:
     // We shouldn't reach here unless there is a bug in gateset

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -230,7 +230,7 @@ public:
     return chunk_container_.lock()->trace(chunk_pos_, row, count);
   }
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaStream_t stream(void) {
     return std::static_pointer_cast<DeviceChunkContainer<data_t>>(
                chunk_container_.lock())

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -49,7 +49,7 @@ DISABLE_WARNING_POP
 #define QV_PROBABILITY_BUFFER_SIZE 4
 #define QV_NUM_INTERNAL_REGS 4
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 #define AERDeviceVector thrust::device_vector
 #else
 #define AERDeviceVector thrust::host_vector
@@ -58,7 +58,7 @@ DISABLE_WARNING_POP
 
 #include "framework/utils.hpp"
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 #include "simulators/statevector/chunk/cuda_kernels.hpp"
 #endif
 
@@ -144,7 +144,7 @@ public:
 
   virtual void set_device(void) const {}
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   virtual cudaStream_t stream(uint_t iChunk) const { return nullptr; }
 #endif
 
@@ -395,7 +395,7 @@ void ChunkContainer<data_t>::Execute(Function func, uint_t iChunk,
       conditional_bit_ = -1; // reset conditional
   }
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaStream_t strm = stream(iChunk);
   if (strm) {
     uint_t nt, nb;
@@ -457,7 +457,7 @@ template <typename Function>
 void ChunkContainer<data_t>::ExecuteSum(double *pSum, Function func,
                                         uint_t iChunk, uint_t count) const {
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   uint_t size = count * func.size(chunk_bits_);
 
   set_device();
@@ -637,7 +637,7 @@ template <typename Function>
 void ChunkContainer<data_t>::ExecuteSum2(double *pSum, Function func,
                                          uint_t iChunk, uint_t count) const {
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   uint_t size = count * func.size(chunk_bits_);
 
   set_device();
@@ -816,7 +816,7 @@ void ChunkContainer<data_t>::apply_matrix(
   } else {
     auto qubits_sorted = qubits;
     std::sort(qubits_sorted.begin(), qubits_sorted.end());
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
     if (N == 3) {
       StoreMatrix(mat, iChunk);
       Execute(MatrixMult8x8<data_t>(qubits, qubits_sorted), iChunk, gid, count);

--- a/src/simulators/statevector/chunk/chunk_manager.hpp
+++ b/src/simulators/statevector/chunk/chunk_manager.hpp
@@ -122,7 +122,7 @@ ChunkManager<data_t>::ChunkManager() {
   num_places_ = 1;
 #else
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (cudaGetDeviceCount(&num_devices_) == cudaSuccess) {
     num_places_ = num_devices_;
   } else {
@@ -248,7 +248,7 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits, int nqubits,
 
       num_buffers = AER_MAX_BUFFERS;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
       num_places_ = num_devices_;
       if (num_threads_per_group_ > 1)
         num_places_ *= num_threads_per_group_;

--- a/src/simulators/statevector/chunk/cuda_kernels.hpp
+++ b/src/simulators/statevector/chunk/cuda_kernels.hpp
@@ -57,7 +57,7 @@ template <typename data_t, typename kernel_t>
 __global__ void dev_apply_function_sum(double *pReduceBuffer, kernel_t func,
                                        uint_t buf_size, uint_t count) {
   // One cache entry per warp/wavefront
-  __shared__ double cache[_MAX_THD/_WS];
+  __shared__ double cache[_MAX_THD / _WS];
   double sum;
   uint_t i, j, iChunk, nw;
 
@@ -79,7 +79,7 @@ __global__ void dev_apply_function_sum(double *pReduceBuffer, kernel_t func,
 
   if (blockDim.x > _WS) {
     // reduce in thread block
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       cache[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();
@@ -135,7 +135,7 @@ dev_apply_function_sum_with_cache(double *pReduceBuffer, kernel_t func,
   if (blockDim.x > _WS) {
     // reduce in thread block
     __syncthreads();
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       ((double *)cache)[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();
@@ -160,7 +160,7 @@ dev_apply_function_sum_with_cache(double *pReduceBuffer, kernel_t func,
 __global__ void dev_reduce_sum(double *pReduceBuffer, uint_t n,
                                uint_t buf_size) {
   // One cache entry per warp/wavefront
-  __shared__ double cache[_MAX_THD/_WS];
+  __shared__ double cache[_MAX_THD / _WS];
   double sum;
   uint_t i, j, iChunk, nw;
 
@@ -180,7 +180,7 @@ __global__ void dev_reduce_sum(double *pReduceBuffer, uint_t n,
 
   if (blockDim.x > _WS) {
     // reduce in thread block
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       cache[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();
@@ -207,7 +207,7 @@ __global__ void
 dev_apply_function_sum_complex(thrust::complex<double> *pReduceBuffer,
                                kernel_t func, uint_t buf_size, uint_t count) {
   // One cache entry per warp/wavefront
-  __shared__ thrust::complex<double> cache[_MAX_THD/_WS];
+  __shared__ thrust::complex<double> cache[_MAX_THD / _WS];
   thrust::complex<double> sum;
   double tr, ti;
   uint_t i, j, iChunk, nw;
@@ -232,7 +232,7 @@ dev_apply_function_sum_complex(thrust::complex<double> *pReduceBuffer,
 
   if (blockDim.x > _WS) {
     // reduce in thread block
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       cache[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();
@@ -259,7 +259,7 @@ dev_apply_function_sum_complex(thrust::complex<double> *pReduceBuffer,
 __global__ void dev_reduce_sum_complex(thrust::complex<double> *pReduceBuffer,
                                        uint_t n, uint_t buf_size) {
   // One cache entry per warp/wavefront
-  __shared__ thrust::complex<double> cache[_MAX_THD/_WS];
+  __shared__ thrust::complex<double> cache[_MAX_THD / _WS];
   thrust::complex<double> sum;
   double tr, ti;
   uint_t i, j, iChunk, nw;
@@ -282,7 +282,7 @@ __global__ void dev_reduce_sum_complex(thrust::complex<double> *pReduceBuffer,
 
   if (blockDim.x > _WS) {
     // reduce in thread block
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       cache[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();
@@ -309,7 +309,7 @@ __global__ void dev_reduce_sum_complex(thrust::complex<double> *pReduceBuffer,
 __global__ void dev_reduce_sum_uint(uint_t *pReduceBuffer, uint_t n,
                                     uint_t buf_size) {
   // One cache entry per warp/wavefront
-  __shared__ uint_t cache[_MAX_THD/_WS];
+  __shared__ uint_t cache[_MAX_THD / _WS];
   uint_t sum;
   uint_t i, j, iChunk, nw;
 
@@ -329,7 +329,7 @@ __global__ void dev_reduce_sum_uint(uint_t *pReduceBuffer, uint_t n,
 
   if (blockDim.x > _WS) {
     // reduce in thread block
-    if ((threadIdx.x & (_WS-1)) == 0) {
+    if ((threadIdx.x & (_WS - 1)) == 0) {
       cache[(threadIdx.x / _WS)] = sum;
     }
     __syncthreads();

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -21,9 +21,8 @@
 #include "misc/gpu_static_properties.hpp"
 
 #ifdef AER_THRUST_CUDA
-  namespace thrust_gpu = thrust::cuda;
+namespace thrust_gpu = thrust::cuda;
 #endif
-
 
 namespace AER {
 namespace QV {
@@ -1107,7 +1106,7 @@ dev_apply_register_blocked_gates(thrust::complex<data_t> *data, int num_gates,
   thrust::complex<double> *matrix_load;
 
   i = blockIdx.x * blockDim.x + threadIdx.x;
-  laneID = i & (_WS-1);
+  laneID = i & (_WS - 1);
 
   // index for this thread
   idx = 0;
@@ -1229,8 +1228,8 @@ dev_apply_shared_memory_blocked_gates(thrust::complex<data_t> *data,
       // warp shuffle to get pair amplitude
       qr = q.real();
       qi = q.imag();
-      qr = __shfl_sync(0xffffffff, qr, iPair & (_WS-1), 32);
-      qi = __shfl_sync(0xffffffff, qi, iPair & (_WS-1), 32);
+      qr = __shfl_sync(0xffffffff, qr, iPair & (_WS - 1), 32);
+      qi = __shfl_sync(0xffffffff, qi, iPair & (_WS - 1), 32);
       qp = thrust::complex<data_t>(qr, qi);
     } else {
       __syncthreads();

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -18,6 +18,13 @@
 #include "simulators/statevector/chunk/chunk_container.hpp"
 #include "simulators/statevector/chunk/thrust_kernels.hpp"
 
+#include "misc/gpu_static_properties.hpp"
+
+#ifdef AER_THRUST_CUDA
+  namespace thrust_gpu = thrust::cuda;
+#endif
+
+
 namespace AER {
 namespace QV {
 namespace Chunk {
@@ -64,7 +71,7 @@ protected:
   reg_t num_blocked_matrix_;
   reg_t num_blocked_qubits_;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   std::vector<cudaStream_t> stream_; // asynchronous execution
 #endif
 
@@ -117,12 +124,12 @@ public:
   void calculate_matrix_buffer_size(int bits);
 
   void set_device(void) const {
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
     cudaSetDevice(device_id_);
 #endif
   }
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaStream_t stream(uint_t iChunk) const {
     if (iChunk >= this->num_chunks_)
       return stream_[(num_matrices_ + iChunk - this->num_chunks_)];
@@ -213,7 +220,7 @@ public:
     ibit = qubit & 63;
     if (iChunk == 0 && creg_host_update_) {
       creg_host_update_ = false;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
       cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_host_.data()),
                       thrust::raw_pointer_cast(cregs_.data()),
                       sizeof(uint_t) * num_matrices_ * n64,
@@ -237,7 +244,7 @@ public:
     ibit = qubit & 63;
     if (iChunk == 0 && creg_host_update_) {
       creg_host_update_ = false;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
       cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_host_.data()),
                       thrust::raw_pointer_cast(cregs_.data()),
                       sizeof(uint_t) * num_matrices_ * n64,
@@ -260,7 +267,7 @@ public:
       n64 = (this->num_creg_bits_ + 63) >> 6;
       creg_dev_update_ = false;
       creg_host_update_ = false;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
       cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_.data()),
                       thrust::raw_pointer_cast(cregs_host_.data()),
                       sizeof(uint_t) * num_matrices_ * n64,
@@ -280,7 +287,7 @@ public:
   void request_creg_update(void) { creg_host_update_ = true; }
 
   void synchronize(uint_t iChunk) {
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
     set_device();
     cudaStreamSynchronize(stream(iChunk));
 #endif
@@ -320,7 +327,7 @@ uint_t DeviceChunkContainer<data_t>::Allocate(int idev, int chunk_bits,
   device_id_ = idev;
   set_device();
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   int ip, nd;
   cudaGetDeviceCount(&nd);
   peer_access_.resize(nd);
@@ -363,7 +370,7 @@ uint_t DeviceChunkContainer<data_t>::Allocate(int idev, int chunk_bits,
 
   reduce_buffer_size_ = 2;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   size_t param_size = sizeof(thrust::complex<double>) * matrix_buffer_size_ +
                       sizeof(uint_t) * params_buffer_size_;
 
@@ -409,7 +416,7 @@ uint_t DeviceChunkContainer<data_t>::Allocate(int idev, int chunk_bits,
 
   uint_t size = num_matrices_ + this->num_buffers_;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   stream_.resize(size);
   for (int i = 0; i < size; i++)
     cudaStreamCreateWithFlags(&stream_[i], cudaStreamNonBlocking);
@@ -485,7 +492,7 @@ void DeviceChunkContainer<data_t>::Deallocate(void) {
   num_blocked_qubits_.clear();
   blocked_qubits_holder_.clear();
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   for (int i = 0; i < stream_.size(); i++)
     cudaStreamDestroy(stream_[i]);
   stream_.clear();
@@ -542,7 +549,7 @@ void DeviceChunkContainer<data_t>::StoreMatrix(
     const std::vector<std::complex<double>> &mat, uint_t iChunk) const {
   set_device();
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaMemcpyAsync(matrix_pointer(iChunk), &mat[0],
                   mat.size() * sizeof(thrust::complex<double>),
                   cudaMemcpyHostToDevice, stream(iChunk));
@@ -574,7 +581,7 @@ void DeviceChunkContainer<data_t>::StoreMatrix(const std::complex<double> *mat,
                                                uint_t size) const {
   set_device();
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaMemcpyAsync(matrix_pointer(iChunk), mat,
                   size * sizeof(thrust::complex<double>),
                   cudaMemcpyHostToDevice, stream(iChunk));
@@ -606,7 +613,7 @@ void DeviceChunkContainer<data_t>::StoreUintParams(
     const std::vector<uint_t> &prm, uint_t iChunk) const {
   set_device();
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaMemcpyAsync(param_pointer(iChunk), &prm[0], prm.size() * sizeof(uint_t),
                   cudaMemcpyHostToDevice, stream(iChunk));
 
@@ -635,7 +642,7 @@ void DeviceChunkContainer<data_t>::StoreUintParams(
 template <typename data_t>
 void DeviceChunkContainer<data_t>::CopyIn(Chunk<data_t> &src, uint_t iChunk) {
   uint_t size = 1ull << this->chunk_bits_;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (src.device() >= 0) {
     if (peer_access(src.device())) {
       cudaMemcpyAsync(chunk_pointer(iChunk), src.pointer(),
@@ -667,7 +674,7 @@ template <typename data_t>
 void DeviceChunkContainer<data_t>::CopyOut(Chunk<data_t> &dest, uint_t iChunk) {
   uint_t size = 1ull << this->chunk_bits_;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (dest.device() >= 0) {
     if (peer_access(dest.device())) {
       cudaMemcpyAsync(dest.pointer(), chunk_pointer(iChunk),
@@ -735,7 +742,7 @@ void DeviceChunkContainer<data_t>::Swap(Chunk<data_t> &src, uint_t iChunk,
     size = 1ull << this->chunk_bits_;
 
   set_device();
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (src.device() >= 0) {
     if (peer_access(src.device())) {
       this->Execute(BufferSwap_func<data_t>(chunk_pointer(iChunk) + dest_offset,
@@ -785,8 +792,8 @@ void DeviceChunkContainer<data_t>::Swap(Chunk<data_t> &src, uint_t iChunk,
 template <typename data_t>
 void DeviceChunkContainer<data_t>::Zero(uint_t iChunk, uint_t count) {
   set_device();
-#ifdef AER_THRUST_CUDA
-  thrust::fill_n(thrust::cuda::par.on(stream(iChunk)),
+#ifdef AER_THRUST_GPU
+  thrust::fill_n(thrust_gpu::par.on(stream(iChunk)),
                  data_.begin() + (iChunk << this->chunk_bits_), count, 0.0);
 #else
   if (this->omp_threads_ > 1)
@@ -810,15 +817,15 @@ reg_t DeviceChunkContainer<data_t>::sample_measure(
   strided_range<thrust::complex<data_t> *> iter(
       chunk_pointer(iChunk), chunk_pointer(iChunk + count), stride);
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 
   if (dot)
-    thrust::transform_inclusive_scan(thrust::cuda::par.on(stream(iChunk)),
+    thrust::transform_inclusive_scan(thrust_gpu::par.on(stream(iChunk)),
                                      iter.begin(), iter.end(), iter.begin(),
                                      complex_dot_scan<data_t>(),
                                      thrust::plus<thrust::complex<data_t>>());
   else
-    thrust::inclusive_scan(thrust::cuda::par.on(stream(iChunk)), iter.begin(),
+    thrust::inclusive_scan(thrust_gpu::par.on(stream(iChunk)), iter.begin(),
                            iter.end(), iter.begin(),
                            thrust::plus<thrust::complex<data_t>>());
 
@@ -847,7 +854,7 @@ reg_t DeviceChunkContainer<data_t>::sample_measure(
     cudaMemcpyAsync(pRnd, &rnds[i], nshots * sizeof(double),
                     cudaMemcpyHostToDevice, stream(iChunk));
 
-    thrust::lower_bound(thrust::cuda::par.on(stream(iChunk)), iter.begin(),
+    thrust::lower_bound(thrust_gpu::par.on(stream(iChunk)), iter.begin(),
                         iter.end(), rnd_dev_ptr, rnd_dev_ptr + nshots,
                         params_.begin() + (iBuf * params_buffer_size_),
                         complex_less<data_t>());
@@ -915,7 +922,7 @@ void DeviceChunkContainer<data_t>::set_blocked_qubits(uint_t iChunk,
   for (i = 0; i < qubits.size(); i++) {
     blocked_qubits_holder_[iBlock * QV_MAX_REGISTERS + i] = qubits_sorted[i];
   }
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   set_device();
   cudaMemcpyAsync(param_pointer(iChunk), (uint_t *)&qubits_sorted[0],
                   qubits.size() * sizeof(uint_t), cudaMemcpyHostToDevice,
@@ -992,7 +999,7 @@ void DeviceChunkContainer<data_t>::queue_blocked_gate(
     apply_blocked_gates(iChunk);
   }
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   BlockedGateParams params;
 
   params.mask_ = mask;
@@ -1083,7 +1090,7 @@ void DeviceChunkContainer<data_t>::queue_blocked_gate(
 #endif
 }
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 
 template <typename data_t>
 __global__ void
@@ -1100,7 +1107,7 @@ dev_apply_register_blocked_gates(thrust::complex<data_t> *data, int num_gates,
   thrust::complex<double> *matrix_load;
 
   i = blockIdx.x * blockDim.x + threadIdx.x;
-  laneID = i & 31;
+  laneID = i & (_WS-1);
 
   // index for this thread
   idx = 0;
@@ -1222,8 +1229,8 @@ dev_apply_shared_memory_blocked_gates(thrust::complex<data_t> *data,
       // warp shuffle to get pair amplitude
       qr = q.real();
       qi = q.imag();
-      qr = __shfl_sync(0xffffffff, qr, iPair & 31, 32);
-      qi = __shfl_sync(0xffffffff, qi, iPair & 31, 32);
+      qr = __shfl_sync(0xffffffff, qr, iPair & (_WS-1), 32);
+      qi = __shfl_sync(0xffffffff, qi, iPair & (_WS-1), 32);
       qp = thrust::complex<data_t>(qr, qi);
     } else {
       __syncthreads();
@@ -1298,7 +1305,7 @@ void DeviceChunkContainer<data_t>::apply_blocked_gates(uint_t iChunk) {
   if (num_blocked_gates_[iBlock] == 0)
     return;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 
   uint_t size;
   uint_t *pQubits;
@@ -1351,7 +1358,7 @@ void DeviceChunkContainer<data_t>::apply_blocked_gates(uint_t iChunk) {
 template <typename data_t>
 void DeviceChunkContainer<data_t>::copy_to_probability_buffer(
     std::vector<double> &buf, int pos) {
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   set_device();
   cudaMemcpyAsync(probability_buffer(0) + pos * this->num_chunks_, &buf[0],
                   buf.size() * sizeof(double), cudaMemcpyHostToDevice,

--- a/src/simulators/statevector/chunk/thrust_kernels.hpp
+++ b/src/simulators/statevector/chunk/thrust_kernels.hpp
@@ -38,7 +38,7 @@ DISABLE_WARNING_POP
 
 #include "framework/utils.hpp"
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
 #include "simulators/statevector/chunk/cuda_kernels.hpp"
 #endif
 
@@ -60,7 +60,7 @@ protected:
   uint_t *cregs_;
   uint_t num_creg_bits_;
   int_t conditional_bit_;
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
   uint_t index_offset_;
 #endif
 public:
@@ -70,7 +70,7 @@ public:
     cregs_ = NULL;
     num_creg_bits_ = 0;
     conditional_bit_ = -1;
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
     index_offset_ = 0;
 #endif
   }
@@ -86,7 +86,7 @@ public:
   }
   void set_conditional(int_t bit) { conditional_bit_ = bit; }
 
-#ifndef AER_THRUST_CUDA
+#ifndef AER_THRUST_GPU
   void set_index_offset(uint_t i) { index_offset_ = i; }
 #endif
 

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -93,7 +93,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Return the string name of the QubitVector class
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   static std::string name() { return "statevector_gpu"; }
 #else
   static std::string name() { return "statevector_thrust"; }
@@ -326,7 +326,7 @@ public:
   // for batched optimization
   //-----------------------------------------------------------------------
   virtual bool batched_optimization_supported(void) {
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
     if (enable_batch_)
       return true;
     else
@@ -1022,7 +1022,7 @@ std::complex<double> QubitVectorThrust<data_t>::inner_product() const {
 
   vec0 = (data_t *)chunk_.pointer();
   vec1 = (data_t *)thrust::raw_pointer_cast(checkpoint_.data());
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   cudaStream_t strm = chunk_.stream();
   if (strm)
     dot = thrust::inner_product(thrust::device, vec0, vec0 + data_size_ * 2,
@@ -1386,7 +1386,7 @@ template <typename Function>
 void QubitVectorThrust<data_t>::apply_function_sum(double *pSum, Function func,
                                                    bool async) const {
   uint_t count = 1;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (!cuStateVec_enable_ && func.batch_enable() &&
       ((multi_chunk_distribution_ && chunk_.device() >= 0 &&
         num_qubits_ == num_qubits()) ||
@@ -1416,7 +1416,7 @@ template <typename Function>
 void QubitVectorThrust<data_t>::apply_function_sum2(double *pSum, Function func,
                                                     bool async) const {
   uint_t count = 1;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (!cuStateVec_enable_ && func.batch_enable() &&
       ((multi_chunk_distribution_ && chunk_.device() >= 0 &&
         num_qubits_ == num_qubits()) ||
@@ -1917,7 +1917,7 @@ double QubitVectorThrust<data_t>::norm() const {
   double ret;
   uint_t count = 1;
 
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (enable_batch_ && ((multi_chunk_distribution_ && chunk_.device() >= 0) ||
                         !multi_chunk_distribution_)) {
     if (chunk_.pos() != 0)
@@ -1939,7 +1939,7 @@ template <typename data_t>
 double QubitVectorThrust<data_t>::norm(const reg_t &qubits,
                                        const cvector_t<double> &mat) const {
   uint_t count = 1;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if (!cuStateVec_enable_ &&
       ((multi_chunk_distribution_ && chunk_.device() >= 0 &&
         num_qubits_ == num_qubits()) ||
@@ -2566,7 +2566,7 @@ template <typename data_t>
 reg_t QubitVectorThrust<data_t>::sample_measure(
     const std::vector<double> &rnds) const {
   uint_t count = 1;
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   if ((multi_chunk_distribution_ && chunk_.device() >= 0) || enable_batch_) {
     if (chunk_.pos() != 0)
       return reg_t(); // first chunk execute all in batch

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -50,7 +50,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Return the string name of the class
-#ifdef AER_THRUST_CUDA
+#ifdef AER_THRUST_GPU
   static std::string name() { return "unitary_gpu"; }
 #else
   static std::string name() { return "unitary_thrust"; }

--- a/test/terra/backends/aer_simulator/test_cliffords.py
+++ b/test/terra/backends/aer_simulator/test_cliffords.py
@@ -28,6 +28,10 @@ SUPPORTED_METHODS = [
     "tensor_network",
 ]
 
+SUPPORTED_ECR_METHODS = [
+    "stabilizer",
+]
+
 
 @ddt
 class TestCliffords(SimulatorTestCase):
@@ -241,6 +245,20 @@ class TestCliffords(SimulatorTestCase):
         result = backend.run(circuits, shots=shots).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
+
+    # ---------------------------------------------------------------------
+    # Test ecr gate
+    # ---------------------------------------------------------------------
+    @supported_methods(SUPPORTED_ECR_METHODS)
+    def test_ecr_gate_nondeterministic(self, method, device):
+        """Test ecr gate circuits"""
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 100
+        circuits = ref_2q_clifford.ecr_gate_circuits_nondeterministic(final_measure=True)
+        targets = ref_2q_clifford.ecr_gate_counts_nondeterministic(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
     # Test identity gate

--- a/test/terra/reference/ref_2q_clifford.py
+++ b/test/terra/reference/ref_2q_clifford.py
@@ -687,3 +687,82 @@ def swap_gate_unitary_nondeterministic():
         / np.sqrt(2)
     )
     return targets
+
+
+# ==========================================================================
+# ECR gate
+# ==========================================================================
+
+
+def ecr_gate_circuits_nondeterministic(final_measure=True):
+    """ECR-gate test circuits with nondeterministic counts."""
+    circuits = []
+    qr = QuantumRegister(2)
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # ECR, |00> state
+    circuit = QuantumCircuit(*regs)
+    circuit.ecr(qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # ECR, |01> state
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.ecr(qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # ECR, |10> state
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[1])
+    circuit.ecr(qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # ECR, |11> state
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.x(qr[1])
+    circuit.ecr(qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+    return circuits
+
+
+def ecr_gate_counts_nondeterministic(shots, hex_counts=True):
+    """ECR-gate circuits reference counts."""
+    targets = []
+    if hex_counts:
+        # ECR, |00> state
+        targets.append({"0x1": shots / 2, "0x3": shots / 2})
+        # ECR, |01> state
+        targets.append({"0x0": shots / 2, "0x2": shots / 2})
+        # ECR, |10> state
+        targets.append({"0x1": shots / 2, "0x3": shots / 2})
+        # ECR, |11> state
+        targets.append({"0x0": shots / 2, "0x2": shots / 2})
+
+    else:
+        # ECR, |00> state
+        targets.append({"01": shots / 2, "11": shots / 2})
+        # ECR, |01> state
+        targets.append({"00": shots / 2, "10": shots / 2})
+        # ECR, |10> state
+        targets.append({"01": shots / 2, "11": shots / 2})
+        # ECR, |11> state
+        targets.append({"00": shots / 2, "10": shots / 2})
+    return targets


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Change the the existing CUDA implementation to a generic GPU implementation.


### Details and comments
Prepare the CUDA implementation so that it can accommodate other GPU targets. This creates the `AER_THRUST_GPU` macros to indicate that a code section is meant to GPU implementation and  `AER_THRUST_CUDA` to indicate what is specific for CUDA. Also, adds the required  build system changes.
